### PR TITLE
Add mixin types feature to ADT

### DIFF
--- a/test/test_mixins.py
+++ b/test/test_mixins.py
@@ -1,0 +1,38 @@
+"""
+Tests of mixin class feature
+"""
+
+import pytest
+
+from asdl_adt import ADT
+
+
+def test_basic_mixin():
+    """
+    Test that a basic mixin class is properly injected into the given sum type
+    alternative, and not the others.
+    """
+
+    class MixinA:  # pylint: disable=C0115,C0116,R0903
+        def double(self):
+            return self.update(x=2 * self.x)
+
+    mixin_grammar = ADT(
+        """
+        module test_basic_mixin {
+            prod = ( int x, int y )
+            sum = A( int x )
+                | B( float y )
+                | C( int x, int y )
+        }
+        """,
+        mixin_types={
+            "A": MixinA,
+        },
+    )
+
+    obj = mixin_grammar.A(3)
+    assert obj.double() == mixin_grammar.A(6)
+
+    with pytest.raises(AttributeError, match="'B' object has no attribute 'double'"):
+        mixin_grammar.B(3.14).double()

--- a/test/test_module_caching.py
+++ b/test/test_module_caching.py
@@ -1,0 +1,16 @@
+"""
+Coverage-focused test for object identity of same-named ADT types.
+"""
+
+from asdl_adt import ADT
+
+
+def test_module_caching():
+    """
+    Test that creating a second module with the same name returns the same
+    object identically as the first call
+    """
+
+    grammar_a = ADT("module cache_test { foo = ( int bar ) }")
+    grammar_b = ADT("module cache_test { foo = ( int bar ) }")
+    assert grammar_a is grammar_b

--- a/test/test_ueq_grammar.py
+++ b/test/test_ueq_grammar.py
@@ -46,7 +46,7 @@ def fixture_ueq_grammar():
                  | Scale( int coeff, expr e )
         }
         """,
-        {"sym": Sym},
+        ext_types={"sym": Sym},
     )
 
 


### PR DESCRIPTION
Now, by specifying mixin_types={'prod': cls} one can inject an additional base class to any production `prod`. This enables users to attach methods to the generated classes. It might also be useful to static type checkers by setting a base type to be one of Python 3.8's "Protocol" types.